### PR TITLE
Browser support flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,17 @@ speechRecognition.stop();
 
 # Browser support
 
-This polyfill is supported on all browsers except for Internet Explorer and very old versions of other browsers. On these browsers, an error will be thrown when creating a `SpeechlySpeechRecognition` object. If you want to detect browser support for the APIs used by this library, check for the following:
-* `window.navigator.mediaDevices` is defined
-* `window.AudioContext` or `window.webkitAudioContext` is defined
+This polyfill is supported on all browsers except for Internet Explorer and very old versions of other browsers. On these browsers, an error will be thrown when creating a `SpeechlySpeechRecognition` object.
 
-If both of these conditions are true, then you can enable your voice-enabled feature. Otherwise, you will need to display some fallback UI.
-
-We will be adding a browser support check in an upcoming version to handle this logic for you.
+The `SpeechlySpeechRecognition` class offers the `hasBrowserSupport` flag to check whether the browser supports the required APIs. We recommend you do the following when creating your speech recognition object:
+```
+if (SpeechlySpeechRecognition.hasBrowserSupport) {
+  const speechRecognition = new SpeechlySpeechRecognition();
+  // Use speech recognition
+} else {
+  // Show some fallback UI
+}
+```
 
 # Examples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,13 +16,13 @@ is incomplete, but should enable the majority of use cases
 
 - [SpeechRecognition](interfaces/speechrecognition.md)
 - [SpeechRecognitionAlternative](interfaces/speechrecognitionalternative.md)
+- [SpeechRecognitionClass](interfaces/speechrecognitionclass.md)
 - [SpeechRecognitionEvent](interfaces/speechrecognitionevent.md)
 - [SpeechRecognitionResult](interfaces/speechrecognitionresult.md)
 
 ### Type aliases
 
 - [SpeechEndCallback](README.md#speechendcallback)
-- [SpeechRecognitionClass](README.md#speechrecognitionclass)
 - [SpeechRecognitionEventCallback](README.md#speechrecognitioneventcallback)
 
 ### Functions
@@ -44,22 +44,6 @@ Callback that is invoked when transcription ends
 **Returns:** *void*
 
 Defined in: [types.ts:64](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L64)
-
-___
-
-### SpeechRecognitionClass
-
-Ƭ **SpeechRecognitionClass**: () => [*SpeechRecognition*](interfaces/speechrecognition.md)
-
-Class that implements the SpeechRecognition interface
-
-#### Type declaration:
-
-\+ (): [*SpeechRecognition*](interfaces/speechrecognition.md)
-
-**Returns:** [*SpeechRecognition*](interfaces/speechrecognition.md)
-
-Defined in: [types.ts:108](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L108)
 
 ___
 
@@ -89,7 +73,7 @@ Defined in: [types.ts:58](https://github.com/JamesBrill/speech-recognition-polyf
 
 ### createSpeechlySpeechRecognition
 
-▸ `Const`**createSpeechlySpeechRecognition**(`appId`: *string*): [*SpeechRecognitionClass*](README.md#speechrecognitionclass)
+▸ `Const`**createSpeechlySpeechRecognition**(`appId`: *string*): [*SpeechRecognitionClass*](interfaces/speechrecognitionclass.md)
 
 Returns a SpeechRecognition implementation that uses a given Speechly app ID
 to generate transcriptions using the Speechly API
@@ -100,7 +84,7 @@ to generate transcriptions using the Speechly API
 | :------ | :------ | :------ |
 | `appId` | *string* | Speechly app ID |
 
-**Returns:** [*SpeechRecognitionClass*](README.md#speechrecognitionclass)
+**Returns:** [*SpeechRecognitionClass*](interfaces/speechrecognitionclass.md)
 
 Class that implements the SpeechRecognition interface
 

--- a/docs/interfaces/speechrecognitionclass.md
+++ b/docs/interfaces/speechrecognitionclass.md
@@ -1,0 +1,37 @@
+[@speechly/speech-recognition-polyfill](../README.md) / SpeechRecognitionClass
+
+# Interface: SpeechRecognitionClass
+
+Class that implements the SpeechRecognition interface
+
+## Table of contents
+
+### Constructors
+
+- [constructor](speechrecognitionclass.md#constructor)
+
+### Properties
+
+- [hasBrowserSupport](speechrecognitionclass.md#hasbrowsersupport)
+
+## Constructors
+
+### constructor
+
+\+ **new SpeechRecognitionClass**(): [*SpeechRecognition*](speechrecognition.md)
+
+Constructor for a SpeechRecognition implementation
+
+**Returns:** [*SpeechRecognition*](speechrecognition.md)
+
+Defined in: [types.ts:112](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L112)
+
+## Properties
+
+### hasBrowserSupport
+
+• `Readonly` **hasBrowserSupport**: *boolean*
+
+Does the browser support the APIs needed for this polyfill?
+
+Defined in: [types.ts:112](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L112)

--- a/etc/speech-recognition-polyfill.api.md
+++ b/etc/speech-recognition-polyfill.api.md
@@ -32,7 +32,10 @@ interface SpeechRecognitionAlternative_2 {
 export { SpeechRecognitionAlternative_2 as SpeechRecognitionAlternative }
 
 // @public
-export type SpeechRecognitionClass = new () => SpeechRecognition_2;
+export interface SpeechRecognitionClass {
+    new (): SpeechRecognition_2;
+    readonly hasBrowserSupport: boolean;
+}
 
 // @public
 interface SpeechRecognitionEvent_2 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/speech-recognition-polyfill",
-  "version": "1.0.0",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/speech-recognition-polyfill",
-  "version": "1.0.0",
+  "version": "0.0.7",
   "description": "Polyfill for the Speech Recognition API using Speechly",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/createSpeechRecognition.test.ts
+++ b/src/createSpeechRecognition.test.ts
@@ -1,5 +1,13 @@
 import createSpeechlySpeechRecognition from './createSpeechRecognition';
 import {
+  mockUndefinedWindow,
+  mockUndefinedNavigator,
+  mockMediaDevices,
+  mockUndefinedMediaDevices,
+  mockAudioContext,
+  mockWebkitAudioContext,
+  mockUndefinedAudioContext,
+  mockUndefinedWebkitAudioContext,
   expectSentenceToBeTranscribedWithFinalResult,
   expectSentenceToBeTranscribedWithInterimAndFinalResults,
   expectSentenceToBeTranscribedWithFirstInitialResult,
@@ -291,5 +299,61 @@ describe('createSpeechlySpeechRecognition', () => {
 
     expect(mockOnResult).toHaveBeenCalledTimes(1);
     expectSentenceToBeTranscribedWithFirstInitialResult(SENTENCE_ONE, mockOnResult);
+  })
+
+  it('sets hasBrowserSupport to true when required APIs are defined (non-WebKit)', async () => {
+    mockAudioContext();
+    mockUndefinedWebkitAudioContext();
+    mockMediaDevices();
+
+    const SpeechRecognition = createSpeechlySpeechRecognition('app id');
+
+    expect(SpeechRecognition.hasBrowserSupport).toEqual(true);
+  })
+
+  it('sets hasBrowserSupport to true when required APIs are defined (WebKit)', async () => {
+    mockUndefinedAudioContext();
+    mockWebkitAudioContext();
+    mockMediaDevices();
+
+    const SpeechRecognition = createSpeechlySpeechRecognition('app id');
+
+    expect(SpeechRecognition.hasBrowserSupport).toEqual(true);
+  })
+
+  it('sets hasBrowserSupport to false when all AudioContext APIs are undefined', async () => {
+    mockUndefinedAudioContext();
+    mockUndefinedWebkitAudioContext();
+    mockMediaDevices();
+
+    const SpeechRecognition = createSpeechlySpeechRecognition('app id');
+
+    expect(SpeechRecognition.hasBrowserSupport).toEqual(false);
+  })
+
+  it('sets hasBrowserSupport to false when MediaDevices API is undefined', async () => {
+    mockAudioContext();
+    mockUndefinedMediaDevices();
+
+    const SpeechRecognition = createSpeechlySpeechRecognition('app id');
+
+    expect(SpeechRecognition.hasBrowserSupport).toEqual(false);
+  })
+
+  it('sets hasBrowserSupport to false when Navigator API is undefined', async () => {
+    mockAudioContext();
+    mockUndefinedNavigator();
+
+    const SpeechRecognition = createSpeechlySpeechRecognition('app id');
+
+    expect(SpeechRecognition.hasBrowserSupport).toEqual(false);
+  })
+
+  it('sets hasBrowserSupport to false when window is undefined', async () => {
+    mockUndefinedWindow();
+
+    const SpeechRecognition = createSpeechlySpeechRecognition('app id');
+
+    expect(SpeechRecognition.hasBrowserSupport).toEqual(false);
   })
 })

--- a/src/createSpeechRecognition.ts
+++ b/src/createSpeechRecognition.ts
@@ -16,7 +16,14 @@ import {
  * @public
  */
 export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitionClass => {
+  const browserSupportsAudioApis: boolean =
+    typeof window !== 'undefined' &&
+    window.navigator?.mediaDevices !== undefined &&
+    (window.AudioContext !== undefined || window.webkitAudioContext !== undefined)
+
   return class SpeechlySpeechRecognition implements SpeechRecognition {
+    static readonly hasBrowserSupport: boolean = browserSupportsAudioApis
+
     private readonly client: Client
     private clientInitialised = false
     private aborted = false

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  webkitAudioContext: typeof AudioContext
+}

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,6 +1,39 @@
+// @ts-nocheck
 import TEST_DATA from './testData';
 
 const { SENTENCE_ONE } = TEST_DATA;
+
+export const mockUndefinedWindow = () => {
+  delete global.window;
+}
+
+export const mockUndefinedNavigator = () => {
+  global.navigator = undefined;
+}
+
+export const mockMediaDevices = () => {
+  global.navigator.mediaDevices = jest.fn();
+}
+
+export const mockUndefinedMediaDevices = () => {
+  global.navigator.mediaDevices = undefined;
+}
+
+export const mockAudioContext = () => {
+  global.AudioContext = jest.fn();
+}
+
+export const mockWebkitAudioContext = () => {
+  global.webkitAudioContext = jest.fn();
+}
+
+export const mockUndefinedAudioContext = () => {
+  global.AudioContext = undefined;
+}
+
+export const mockUndefinedWebkitAudioContext = () => {
+  global.webkitAudioContext = undefined;
+}
 
 export const expectSentenceToBeTranscribedWithFirstInitialResult = (sentence: any, mockOnResult: any) => {
   expect(mockOnResult).toHaveBeenNthCalledWith(1, { results: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,7 +109,7 @@ export interface SpeechRecognitionClass {
   /**
    * Does the browser support the APIs needed for this polyfill?
    */
-  hasBrowserSupport: boolean
+  readonly hasBrowserSupport: boolean
   /**
    * Constructor for a SpeechRecognition implementation
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,4 +105,13 @@ export interface SpeechRecognition {
  * Class that implements the SpeechRecognition interface
  * @public
  */
-export type SpeechRecognitionClass = new () => SpeechRecognition
+export interface SpeechRecognitionClass {
+  /**
+   * Does the browser support the APIs needed for this polyfill?
+   */
+  hasBrowserSupport: boolean
+  /**
+   * Constructor for a SpeechRecognition implementation
+   */
+  new (): SpeechRecognition
+}


### PR DESCRIPTION
### What

Adds a static property `hasBrowserSupport` to the class produced by `createSpeechlySpeechRecognition` that is false if the MediaDevices or AudioContext APIs are not supported by the browser (both of these are required by the underlying Speechly browser client).

### Why

IE11 and some old browsers don't support the APIs needed by this polyfill. Previously, the polyfill would throw errors when being created on these browsers. Now, consumers have a means of checking for browser support before using the polyfill, enabling them to gracefully apply fallback behaviour.
