### PR TITLE
Better error handling implementation/docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,13 +17,20 @@ is incomplete, but should enable the majority of use cases
 - [SpeechRecognition](interfaces/speechrecognition.md)
 - [SpeechRecognitionAlternative](interfaces/speechrecognitionalternative.md)
 - [SpeechRecognitionClass](interfaces/speechrecognitionclass.md)
+- [SpeechRecognitionErrorEvent](interfaces/speechrecognitionerrorevent.md)
 - [SpeechRecognitionEvent](interfaces/speechrecognitionevent.md)
 - [SpeechRecognitionResult](interfaces/speechrecognitionresult.md)
 
 ### Type aliases
 
 - [SpeechEndCallback](README.md#speechendcallback)
+- [SpeechErrorCallback](README.md#speecherrorcallback)
 - [SpeechRecognitionEventCallback](README.md#speechrecognitioneventcallback)
+
+### Variables
+
+- [MicrophoneNotAllowedError](README.md#microphonenotallowederror)
+- [SpeechRecognitionFailedError](README.md#speechrecognitionfailederror)
 
 ### Functions
 
@@ -43,7 +50,29 @@ Callback that is invoked when transcription ends
 
 **Returns:** *void*
 
-Defined in: [types.ts:64](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L64)
+Defined in: [types.ts:97](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L97)
+
+___
+
+### SpeechErrorCallback
+
+Ƭ **SpeechErrorCallback**: (`speechRecognitionErrorEvent`: [*SpeechRecognitionErrorEvent*](interfaces/speechrecognitionerrorevent.md)) => *void*
+
+Callback that is invoked when an error occurs
+
+#### Type declaration:
+
+▸ (`speechRecognitionErrorEvent`: [*SpeechRecognitionErrorEvent*](interfaces/speechrecognitionerrorevent.md)): *void*
+
+#### Parameters:
+
+| Name | Type |
+| :------ | :------ |
+| `speechRecognitionErrorEvent` | [*SpeechRecognitionErrorEvent*](interfaces/speechrecognitionerrorevent.md) |
+
+**Returns:** *void*
+
+Defined in: [types.ts:103](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L103)
 
 ___
 
@@ -67,7 +96,27 @@ Callback that is invoked whenever the transcript gets updated
 
 **Returns:** *void*
 
-Defined in: [types.ts:58](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L58)
+Defined in: [types.ts:91](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L91)
+
+## Variables
+
+### MicrophoneNotAllowedError
+
+• `Const` **MicrophoneNotAllowedError**: [*SpeechRecognitionErrorEvent*](interfaces/speechrecognitionerrorevent.md)
+
+Error emitted when the user does not give permission to use the microphone
+
+Defined in: [types.ts:72](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L72)
+
+___
+
+### SpeechRecognitionFailedError
+
+• `Const` **SpeechRecognitionFailedError**: [*SpeechRecognitionErrorEvent*](interfaces/speechrecognitionerrorevent.md)
+
+Generic error when speech recognition fails due to an unknown cause
+
+Defined in: [types.ts:81](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L81)
 
 ## Functions
 
@@ -88,4 +137,4 @@ to generate transcriptions using the Speechly API
 
 Class that implements the SpeechRecognition interface
 
-Defined in: [createSpeechRecognition.ts:18](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/createSpeechRecognition.ts#L18)
+Defined in: [createSpeechRecognition.ts:21](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/createSpeechRecognition.ts#L21)

--- a/docs/interfaces/speechrecognition.md
+++ b/docs/interfaces/speechrecognition.md
@@ -13,6 +13,7 @@ can be used for basic transcription
 - [continuous](speechrecognition.md#continuous)
 - [interimResults](speechrecognition.md#interimresults)
 - [onend](speechrecognition.md#onend)
+- [onerror](speechrecognition.md#onerror)
 - [onresult](speechrecognition.md#onresult)
 - [start](speechrecognition.md#start)
 - [stop](speechrecognition.md#stop)
@@ -31,9 +32,9 @@ Stop transcribing utterances received from the microphone, and cut off the curre
 
 **Returns:** *Promise*<void\>
 
-Defined in: [types.ts:101](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L101)
+Defined in: [types.ts:145](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L145)
 
-Defined in: [types.ts:101](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L101)
+Defined in: [types.ts:145](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L145)
 
 ___
 
@@ -43,7 +44,7 @@ ___
 
 Should the microphone listen continuously (true) or should it stop after the first utterance (false)?
 
-Defined in: [types.ts:75](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L75)
+Defined in: [types.ts:114](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L114)
 
 ___
 
@@ -54,7 +55,7 @@ ___
 Should interim results be emitted? These are parts of an ongoing utterance for which transcription hasn't
 completed yet
 
-Defined in: [types.ts:80](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L80)
+Defined in: [types.ts:119](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L119)
 
 ___
 
@@ -66,7 +67,19 @@ Callback that is invoked when transcription ends
 
 **`param`** Event containing updates to the transcript
 
-Defined in: [types.ts:89](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L89)
+Defined in: [types.ts:128](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L128)
+
+___
+
+### onerror
+
+• **onerror**: [*SpeechErrorCallback*](../README.md#speecherrorcallback)
+
+Callback that is invoked when an error occurs
+
+**`param`** Event containing details of the error
+
+Defined in: [types.ts:133](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L133)
 
 ___
 
@@ -76,7 +89,7 @@ ___
 
 Callback that is invoked whenever the transcript updates
 
-Defined in: [types.ts:84](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L84)
+Defined in: [types.ts:123](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L123)
 
 ___
 
@@ -92,9 +105,9 @@ Start transcribing utterances received from the microphone
 
 **Returns:** *Promise*<void\>
 
-Defined in: [types.ts:93](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L93)
+Defined in: [types.ts:137](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L137)
 
-Defined in: [types.ts:93](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L93)
+Defined in: [types.ts:137](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L137)
 
 ___
 
@@ -110,6 +123,6 @@ Stop transcribing utterances received from the microphone, but finish processing
 
 **Returns:** *Promise*<void\>
 
-Defined in: [types.ts:97](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L97)
+Defined in: [types.ts:141](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L141)
 
-Defined in: [types.ts:97](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L97)
+Defined in: [types.ts:141](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L141)

--- a/docs/interfaces/speechrecognitionclass.md
+++ b/docs/interfaces/speechrecognitionclass.md
@@ -24,7 +24,7 @@ Constructor for a SpeechRecognition implementation
 
 **Returns:** [*SpeechRecognition*](speechrecognition.md)
 
-Defined in: [types.ts:112](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L112)
+Defined in: [types.ts:156](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L156)
 
 ## Properties
 
@@ -34,4 +34,4 @@ Defined in: [types.ts:112](https://github.com/JamesBrill/speech-recognition-poly
 
 Does the browser support the APIs needed for this polyfill?
 
-Defined in: [types.ts:112](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L112)
+Defined in: [types.ts:156](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L156)

--- a/docs/interfaces/speechrecognitionerrorevent.md
+++ b/docs/interfaces/speechrecognitionerrorevent.md
@@ -1,0 +1,32 @@
+[@speechly/speech-recognition-polyfill](../README.md) / SpeechRecognitionErrorEvent
+
+# Interface: SpeechRecognitionErrorEvent
+
+Data associated with an error emitted from the recognition service
+
+## Table of contents
+
+### Properties
+
+- [error](speechrecognitionerrorevent.md#error)
+- [message](speechrecognitionerrorevent.md#message)
+
+## Properties
+
+### error
+
+• **error**: ``"not-allowed"`` \| ``"audio-capture"``
+
+Type of error raised
+
+Defined in: [types.ts:61](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L61)
+
+___
+
+### message
+
+• **message**: *string*
+
+Message describing the error in more detail
+
+Defined in: [types.ts:65](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L65)

--- a/etc/speech-recognition-polyfill.api.md
+++ b/etc/speech-recognition-polyfill.api.md
@@ -8,7 +8,13 @@
 export const createSpeechlySpeechRecognition: (appId: string) => SpeechRecognitionClass;
 
 // @public
+export const MicrophoneNotAllowedError: SpeechRecognitionErrorEvent_2;
+
+// @public
 export type SpeechEndCallback = () => void;
+
+// @public
+export type SpeechErrorCallback = (speechRecognitionErrorEvent: SpeechRecognitionErrorEvent_2) => void;
 
 // @public
 interface SpeechRecognition_2 {
@@ -16,6 +22,7 @@ interface SpeechRecognition_2 {
     continuous: boolean;
     interimResults: boolean;
     onend: SpeechEndCallback;
+    onerror: SpeechErrorCallback;
     onresult: SpeechRecognitionEventCallback;
     start: () => Promise<void>;
     stop: () => Promise<void>;
@@ -38,6 +45,14 @@ export interface SpeechRecognitionClass {
 }
 
 // @public
+interface SpeechRecognitionErrorEvent_2 {
+    error: 'not-allowed' | 'audio-capture';
+    message: string;
+}
+
+export { SpeechRecognitionErrorEvent_2 as SpeechRecognitionErrorEvent }
+
+// @public
 interface SpeechRecognitionEvent_2 {
     resultIndex: number;
     results: SpeechRecognitionResult_2[];
@@ -47,6 +62,9 @@ export { SpeechRecognitionEvent_2 as SpeechRecognitionEvent }
 
 // @public
 export type SpeechRecognitionEventCallback = (speechRecognitionEvent: SpeechRecognitionEvent_2) => void;
+
+// @public
+export const SpeechRecognitionFailedError: SpeechRecognitionErrorEvent_2;
 
 // @public
 interface SpeechRecognitionResult_2 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/speech-recognition-polyfill",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/speech-recognition-polyfill",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Polyfill for the Speech Recognition API using Speechly",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/createSpeechRecognition.test.ts
+++ b/src/createSpeechRecognition.test.ts
@@ -1,4 +1,6 @@
+import { ErrNoAudioConsent } from '@speechly/browser-client'
 import createSpeechlySpeechRecognition from './createSpeechRecognition';
+import { MicrophoneNotAllowedError, SpeechRecognitionFailedError } from './types';
 import {
   mockUndefinedWindow,
   mockUndefinedNavigator,
@@ -355,5 +357,31 @@ describe('createSpeechlySpeechRecognition', () => {
     const SpeechRecognition = createSpeechlySpeechRecognition('app id');
 
     expect(SpeechRecognition.hasBrowserSupport).toEqual(false);
+  })
+
+  it('calls onerror with MicrophoneNotAllowedError error when no microphone permission given on start', async () => {
+    const SpeechRecognition = createSpeechlySpeechRecognition('app id');
+    const speechRecognition = new SpeechRecognition();
+    const mockOnError = jest.fn();
+    speechRecognition.onerror = mockOnError;
+    mockInitialize.mockImplementationOnce(() => Promise.reject(ErrNoAudioConsent))
+
+    await speechRecognition.start();
+
+    expect(mockOnError).toHaveBeenCalledTimes(1);
+    expect(mockOnError).toHaveBeenCalledWith(MicrophoneNotAllowedError);
+  })
+
+  it('calls onerror with SpeechRecognitionFailedError error when speech recognition fails on start', async () => {
+    const SpeechRecognition = createSpeechlySpeechRecognition('app id');
+    const speechRecognition = new SpeechRecognition();
+    const mockOnError = jest.fn();
+    speechRecognition.onerror = mockOnError;
+    mockInitialize.mockImplementationOnce(() => Promise.reject(new Error('generic failure')))
+
+    await speechRecognition.start();
+
+    expect(mockOnError).toHaveBeenCalledTimes(1);
+    expect(mockOnError).toHaveBeenCalledWith(SpeechRecognitionFailedError);
   })
 })

--- a/src/createSpeechRecognition.ts
+++ b/src/createSpeechRecognition.ts
@@ -116,5 +116,4 @@ export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitio
   }
 }
 
-export { MicrophoneNotAllowedError, SpeechRecognitionFailedError }
 export default createSpeechlySpeechRecognition

--- a/src/createSpeechRecognition.ts
+++ b/src/createSpeechRecognition.ts
@@ -116,4 +116,5 @@ export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitio
   }
 }
 
+export { MicrophoneNotAllowedError, SpeechRecognitionFailedError }
 export default createSpeechlySpeechRecognition

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export interface SpeechRecognitionErrorEvent {
 
 /**
  * Error emitted when the user does not give permission to use the microphone
+ * @public
  */
 export const MicrophoneNotAllowedError: SpeechRecognitionErrorEvent = {
   error: 'not-allowed',
@@ -75,6 +76,7 @@ export const MicrophoneNotAllowedError: SpeechRecognitionErrorEvent = {
 
 /**
  * Generic error when speech recognition fails due to an unknown cause
+ * @public
  */
 export const SpeechRecognitionFailedError: SpeechRecognitionErrorEvent = {
   error: 'audio-capture',

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,37 @@ export interface SpeechRecognitionEvent {
 }
 
 /**
+ * Data associated with an error emitted from the recognition service
+ * @public
+ */
+export interface SpeechRecognitionErrorEvent {
+  /**
+   * Type of error raised
+   */
+  error: 'not-allowed' | 'audio-capture'
+  /**
+   * Message describing the error in more detail
+   */
+  message: string
+}
+
+/**
+ * Error emitted when the user does not give permission to use the microphone
+ */
+export const MicrophoneNotAllowedError: SpeechRecognitionErrorEvent = {
+  error: 'not-allowed',
+  message: 'User did not give permission to use the microphone',
+}
+
+/**
+ * Generic error when speech recognition fails due to an unknown cause
+ */
+export const SpeechRecognitionFailedError: SpeechRecognitionErrorEvent = {
+  error: 'audio-capture',
+  message: 'Speech recognition failed',
+}
+
+/**
  * Callback that is invoked whenever the transcript gets updated
  * @param speechRecognitionEvent - Event containing updates to the transcript
  * @public
@@ -62,6 +93,12 @@ export type SpeechRecognitionEventCallback = (speechRecognitionEvent: SpeechReco
  * @public
  */
 export type SpeechEndCallback = () => void
+
+/**
+ * Callback that is invoked when an error occurs
+ * @public
+ */
+export type SpeechErrorCallback = (speechRecognitionErrorEvent: SpeechRecognitionErrorEvent) => void
 
 /**
  * Subset of the {@link https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition | W3C SpeechRecognition spec} that
@@ -87,6 +124,11 @@ export interface SpeechRecognition {
    * @param speechRecognitionEvent - Event containing updates to the transcript
    */
   onend: SpeechEndCallback
+  /**
+   * Callback that is invoked when an error occurs
+   * @param speechRecognitionErrorEvent - Event containing details of the error
+   */
+  onerror: SpeechErrorCallback
   /**
    * Start transcribing utterances received from the microphone
    */

--- a/test-harness/package-lock.json
+++ b/test-harness/package-lock.json
@@ -10762,9 +10762,9 @@
       }
     },
     "react-speech-recognition": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/react-speech-recognition/-/react-speech-recognition-3.8.0.tgz",
-      "integrity": "sha512-mQ5oVQPt2l95/YKuaB+vGdDCuOKJS/ezwALWgo0w1+/CT3N2jxAdkOzeqvJiBmCLf263sCbkJ/L4fI8R1ij2IA=="
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/react-speech-recognition/-/react-speech-recognition-3.9.0.tgz",
+      "integrity": "sha512-K42atEDi6P6cIuDnqDG0guzKeLaPlxKjZebhoLbgaJAflzhikrUSQnncCDBE3KXSPk7ASfBoykz+uqp8sB8VFQ=="
     },
     "read-pkg": {
       "version": "3.0.0",

--- a/test-harness/package.json
+++ b/test-harness/package.json
@@ -13,7 +13,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
-    "react-speech-recognition": "^3.8.0"
+    "react-speech-recognition": "^3.9.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/test-harness/src/Dictaphone.js
+++ b/test-harness/src/Dictaphone.js
@@ -10,7 +10,8 @@ export default () => {
     finalTranscript,
     resetTranscript,
     listening,
-    browserSupportsSpeechRecognition
+    browserSupportsSpeechRecognition,
+    isMicrophoneAvailable,
   } = useSpeechRecognition()
   useEffect(() => {
     if (interimTranscript !== '') {
@@ -28,6 +29,10 @@ export default () => {
 
   if (!browserSupportsSpeechRecognition) {
     return <span>No browser support</span>
+  }
+
+  if (!isMicrophoneAvailable) {
+    return <span>Please allow access to the microphone</span>
   }
 
   return (


### PR DESCRIPTION
### What

* Rather than bubbling up any errors thrown by the Speechly browser client, the `start` method passes one of two pre-defined error objects to a new `onerror` callback:
  * `MicrophoneNotAllowedError`: emitted when the user does not give permission to use the microphone
  * `SpeechRecognitionFailedError`: any other failure
* This change brings the polyfill closer to the W3C spec in that `start` is meant to emit errors via `onerror` rather than throwing them
* The shape and content of the two errors matches those defined in the [W3C spec](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognitionErrorEvent/error). Note that this does not reflect the full list of possible errors described in the spec due to not all of them being observable in the Speechly browser client
* The test harness uses the [latest version](https://github.com/JamesBrill/react-speech-recognition/releases/tag/v3.9.0) of `react-speech-recognition` and demonstrates its own method of detecting microphone permission denial via `isMicrophoneAvailable`. This is also documented in the README
* A new section has been added to the README to discuss error handling

### Why

As per [this](https://github.com/speechly/speech-recognition-polyfill/issues/6) issue, consumers of this polyfill were unsure how to handle the case where the user denies microphone access. This PR addresses a gap in both the documentation in the README and in the way errors are surfaced to the consumer, moving from a non-standard approach to one compliant with the W3C spec.
