### PR TITLE
Migrate to Speechly Browser Client V2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -137,4 +137,4 @@ to generate transcriptions using the Speechly API
 
 Class that implements the SpeechRecognition interface
 
-Defined in: [createSpeechRecognition.ts:21](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/createSpeechRecognition.ts#L21)
+Defined in: [createSpeechRecognition.ts:27](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/createSpeechRecognition.ts#L27)

--- a/package-lock.json
+++ b/package-lock.json
@@ -883,13 +883,11 @@
       }
     },
     "@speechly/browser-client": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@speechly/browser-client/-/browser-client-1.0.11.tgz",
-      "integrity": "sha512-R+YzeLMNZ3ALltVr6aplw6BE87+nujQ8780PcTFkT/dRIjqxbA2WAR3cE2kGTp5gV/5dHgEwS9K66wu1NucJKA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@speechly/browser-client/-/browser-client-2.4.1.tgz",
+      "integrity": "sha512-5RJDK6GnmMpo3ndoweiifhVGu7gN7eF/pZVjreoV6H4n61lNEXokMBmq+3gNCI92aMtXPXQnYrPmGZC3iYHu5w==",
       "requires": {
-        "async-retry": "^1.3.1",
         "base-64": "^0.1.0",
-        "locale-code": "^2.0.2",
         "uuid": "^8.0.0"
       }
     },
@@ -1365,14 +1363,6 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
-    "async-retry": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
-      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
-      "requires": {
-        "retry": "0.12.0"
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1538,7 +1528,7 @@
     "base-64": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -4044,27 +4034,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "iso-3166-1-alpha-2": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iso-3166-1-alpha-2/-/iso-3166-1-alpha-2-1.0.0.tgz",
-      "integrity": "sha1-vJ4LuU5YTfVGipMpl6KFUuJvl6w=",
-      "requires": {
-        "mout": "^0.11.0"
-      }
-    },
-    "iso-639-1": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-2.1.9.tgz",
-      "integrity": "sha512-owRu9up+Cpx/hwSzm83j6G8PtC7U99UCtPVItsafefNfEgMl+pi8KBwhXwJkJfp6IouyYWFxj8n24SvCWpKZEQ=="
-    },
-    "iso-639-1-zh": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/iso-639-1-zh/-/iso-639-1-zh-2.0.4.tgz",
-      "integrity": "sha1-YbV30U7osMLI5zaXo8iU/gLb1UE=",
-      "requires": {
-        "iso-639-1": "^2.0.0"
-      }
-    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -4870,15 +4839,6 @@
         }
       }
     },
-    "locale-code": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/locale-code/-/locale-code-2.0.2.tgz",
-      "integrity": "sha512-wNcUMwk6Nlc10pnZZXWtKArAOZHhH8p2vohPEIENg7ImwMrib/CwKSvyV4g9Wm7KjylyHzXnEMz4i/W3w57wlw==",
-      "requires": {
-        "iso-3166-1-alpha-2": "~1.0.0",
-        "iso-639-1-zh": "^2.0.4"
-      }
-    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -5088,11 +5048,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
-    },
-    "mout": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
     },
     "ms": {
       "version": "2.1.2",
@@ -6012,11 +5967,6 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
-    },
-    "retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "reusify": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/speech-recognition-polyfill",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/speech-recognition-polyfill",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Polyfill for the Speech Recognition API using Speechly",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@speechly/browser-client": "^1.0.11"
+    "@speechly/browser-client": "^2.4.1"
   },
   "publishConfig": {
     "access": "public"

--- a/src/createSpeechRecognition.test.ts
+++ b/src/createSpeechRecognition.test.ts
@@ -73,7 +73,7 @@ describe('createSpeechlySpeechRecognition', () => {
     mockAttach.mockClear();
   });
 
-  it('calls microphone initialize on browser microphone when starting transcription', async () => {
+  it('calls initialize on browser microphone when starting transcription', async () => {
     const SpeechRecognition = createSpeechlySpeechRecognition('app id');
     const speechRecognition = new SpeechRecognition();
 

--- a/src/createSpeechRecognition.ts
+++ b/src/createSpeechRecognition.ts
@@ -1,4 +1,10 @@
-import { BrowserClient, BrowserMicrophone, ErrNoAudioConsent, Segment } from '@speechly/browser-client'
+import {
+  BrowserClient,
+  BrowserMicrophone,
+  ErrDeviceNotSupported,
+  ErrNoAudioConsent,
+  Segment,
+} from '@speechly/browser-client'
 import {
   SpeechRecognitionEventCallback,
   SpeechEndCallback,
@@ -71,9 +77,11 @@ export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitio
       if (!this.clientInitialised) {
         const microphone = new BrowserMicrophone()
         await microphone.initialize()
-        // TODO: throw?
-        if (microphone.mediaStream === undefined) return
-        await this.client.attach(microphone.mediaStream)
+        const { mediaStream } = microphone
+        if (mediaStream === null || mediaStream === undefined) {
+          throw ErrDeviceNotSupported
+        }
+        await this.client.attach(mediaStream)
         this.clientInitialised = true
       }
     }

--- a/src/createSpeechRecognition.ts
+++ b/src/createSpeechRecognition.ts
@@ -1,4 +1,4 @@
-import { Client, ErrNoAudioConsent, Segment } from '@speechly/browser-client'
+import { BrowserClient, BrowserMicrophone, ErrNoAudioConsent, Segment } from '@speechly/browser-client'
 import {
   SpeechRecognitionEventCallback,
   SpeechEndCallback,
@@ -27,7 +27,7 @@ export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitio
   return class SpeechlySpeechRecognition implements SpeechRecognition {
     static readonly hasBrowserSupport: boolean = browserSupportsAudioApis
 
-    private readonly client: Client
+    private readonly client: BrowserClient
     private clientInitialised = false
     private aborted = false
     private transcribing = false
@@ -39,7 +39,7 @@ export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitio
     onerror: SpeechErrorCallback = () => {}
 
     constructor() {
-      this.client = new Client({ appId })
+      this.client = new BrowserClient({ appId })
       this.client.onSegmentChange(this.handleResult)
     }
 
@@ -47,7 +47,7 @@ export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitio
       try {
         this.aborted = false
         await this.initialise()
-        await this.client.startContext()
+        await this.client.start()
         this.transcribing = true
       } catch (e) {
         if (e === ErrNoAudioConsent) {
@@ -69,7 +69,11 @@ export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitio
 
     private readonly initialise = async (): Promise<void> => {
       if (!this.clientInitialised) {
-        await this.client.initialize()
+        const microphone = new BrowserMicrophone()
+        await microphone.initialize()
+        // TODO: throw?
+        if (microphone.mediaStream === undefined) return
+        await this.client.attach(microphone.mediaStream)
         this.clientInitialised = true
       }
     }
@@ -80,7 +84,7 @@ export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitio
       }
       await this.initialise()
       try {
-        await this.client.stopContext()
+        await this.client.stop()
         this.transcribing = false
         this.onend()
       } catch (e) {

--- a/test-harness/package-lock.json
+++ b/test-harness/package-lock.json
@@ -1361,24 +1361,6 @@
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
       "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
     },
-    "@speechly/browser-client": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@speechly/browser-client/-/browser-client-1.0.11.tgz",
-      "integrity": "sha512-R+YzeLMNZ3ALltVr6aplw6BE87+nujQ8780PcTFkT/dRIjqxbA2WAR3cE2kGTp5gV/5dHgEwS9K66wu1NucJKA==",
-      "requires": {
-        "async-retry": "^1.3.1",
-        "base-64": "^0.1.0",
-        "locale-code": "^2.0.2",
-        "uuid": "^8.0.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
-      }
-    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
@@ -2421,14 +2403,6 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
-    "async-retry": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
-      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
-      "requires": {
-        "retry": "0.12.0"
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2974,11 +2948,6 @@
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
       }
-    },
-    "base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
     },
     "base64-js": {
       "version": "1.3.1",
@@ -6961,27 +6930,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
-    "iso-3166-1-alpha-2": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iso-3166-1-alpha-2/-/iso-3166-1-alpha-2-1.0.0.tgz",
-      "integrity": "sha1-vJ4LuU5YTfVGipMpl6KFUuJvl6w=",
-      "requires": {
-        "mout": "^0.11.0"
-      }
-    },
-    "iso-639-1": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-2.1.9.tgz",
-      "integrity": "sha512-owRu9up+Cpx/hwSzm83j6G8PtC7U99UCtPVItsafefNfEgMl+pi8KBwhXwJkJfp6IouyYWFxj8n24SvCWpKZEQ=="
-    },
-    "iso-639-1-zh": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/iso-639-1-zh/-/iso-639-1-zh-2.0.4.tgz",
-      "integrity": "sha1-YbV30U7osMLI5zaXo8iU/gLb1UE=",
-      "requires": {
-        "iso-639-1": "^2.0.0"
-      }
-    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -7881,15 +7829,6 @@
         }
       }
     },
-    "locale-code": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/locale-code/-/locale-code-2.0.2.tgz",
-      "integrity": "sha512-wNcUMwk6Nlc10pnZZXWtKArAOZHhH8p2vohPEIENg7ImwMrib/CwKSvyV4g9Wm7KjylyHzXnEMz4i/W3w57wlw==",
-      "requires": {
-        "iso-3166-1-alpha-2": "~1.0.0",
-        "iso-639-1-zh": "^2.0.4"
-      }
-    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -8338,11 +8277,6 @@
       "requires": {
         "minimist": "^1.2.5"
       }
-    },
-    "mout": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/test-harness/package.json
+++ b/test-harness/package.json
@@ -5,7 +5,6 @@
   "description": "Example React app using the Speechly speech recognition polyfill",
   "license": "MIT",
   "dependencies": {
-    "@speechly/browser-client": "^1.0.11",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",


### PR DESCRIPTION
### What

The `@speechly/browser-client` dependency has been raised to a new major version (2) and has some breaking API changes. This PR updates the usage of this package to use the new API.

* Most of the changes are straightforward, updating the class and method names of the Speechly client and replacing the call to `Client.initialize` with the creation of a `BrowserMicrophone`, the `MediaStream` of which is passed into the client via its `attach` method
* Now that the client and microphone can be initialised separately in v2, I had the option of initialising the client in the constructor rather than on a user action. I chose not to do this for the following reasons:
  * The client constructor already "pre-warms" the connection to the Speechly API, so initialising the client in the polyfill constructor would not give us any performance gains in terms of network usage
  * `BrowserClient.initialize` is a relatively cheap operation that we can afford to do on user actions. `BrowserClient.attach` already calls `BrowserClient.initialize` under the hood, so I've removed the explicit call
  * I wanted to avoid the complexity of managing the "initialised" state for both the client and microphone, so all initialisation continues to be performed in the polyfill's `initialise` method as one process
  * Ultimately, I decided the performance gains of initialising the client a little earlier were too minimal to justify adding complexity to the polyfill, but I'm happy to be challenged on this
* In theory, the `BrowserMicrophone` should throw an error if it is unable to set its `mediaStream` property. However, just in case this doesn't happen and to reassure the type-checker, I throw the "device not supported" error from `initialise` if the `MediaStream` is missing
* I chose to make this a minor version bump. Although the polyfill has no breaking changes or new features, I'm uncertain if the bump to v2 improves the transcription in some way. A minor bump ensures consumers don't get any surprises if they downgrade from this version to an older one

I manually tested the polyfill in the test harness in several browsers and it performed as expected in all test cases (push to talk, listen once, listen continuously, stop listening).

### Why

Ensures this polyfill continues to get the latest version of the Speechly Browser Client and gives it the _potential_ to benefit from the client's new custom `MediaSource` functionality in future versions.
