### PR TITLE
Add browser APIs that need to be supported to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ speechRecognition.stop();
 
 ## Browser support
 
-This polyfill is supported on all browsers except for Internet Explorer and very old versions of other browsers. On these browsers, an error will be thrown when creating a `SpeechlySpeechRecognition` object.
+This polyfill will work on browsers that support the [MediaDevices](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices) and [AudioContext](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext) APIs, which covers roughly 95% of web users in 2022. The exceptions are Internet Explorer and most browsers from before 2016. On these browsers, an error will be thrown when creating a `SpeechlySpeechRecognition` object.
 
 The `SpeechlySpeechRecognition` class offers the `hasBrowserSupport` flag to check whether the browser supports the required APIs. We recommend you do the following when creating your speech recognition object:
 ```


### PR DESCRIPTION
### What

In the README, adds references and statistics about the browser APIs that the polyfill needs to function.

### Why

As a consumer of this polyfill, it's not obvious whether a given browser will support it or not. Knowing what the underlying APIs are enables consumers to determine this by, for example, looking them up on https://caniuse.com/
