### PR TITLE
Close mic on stop

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ Callback that is invoked when transcription ends
 
 **Returns:** *void*
 
-Defined in: [types.ts:97](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L97)
+Defined in: [types.ts:97](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L97)
 
 ___
 
@@ -72,7 +72,7 @@ Callback that is invoked when an error occurs
 
 **Returns:** *void*
 
-Defined in: [types.ts:103](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L103)
+Defined in: [types.ts:103](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L103)
 
 ___
 
@@ -96,7 +96,7 @@ Callback that is invoked whenever the transcript gets updated
 
 **Returns:** *void*
 
-Defined in: [types.ts:91](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L91)
+Defined in: [types.ts:91](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L91)
 
 ## Variables
 
@@ -106,7 +106,7 @@ Defined in: [types.ts:91](https://github.com/JamesBrill/speech-recognition-polyf
 
 Error emitted when the user does not give permission to use the microphone
 
-Defined in: [types.ts:72](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L72)
+Defined in: [types.ts:72](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L72)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 Generic error when speech recognition fails due to an unknown cause
 
-Defined in: [types.ts:81](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L81)
+Defined in: [types.ts:81](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L81)
 
 ## Functions
 
@@ -137,4 +137,4 @@ to generate transcriptions using the Speechly API
 
 Class that implements the SpeechRecognition interface
 
-Defined in: [createSpeechRecognition.ts:27](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/createSpeechRecognition.ts#L27)
+Defined in: [createSpeechRecognition.ts:27](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/createSpeechRecognition.ts#L27)

--- a/docs/interfaces/speechrecognition.md
+++ b/docs/interfaces/speechrecognition.md
@@ -32,9 +32,9 @@ Stop transcribing utterances received from the microphone, and cut off the curre
 
 **Returns:** *Promise*<void\>
 
-Defined in: [types.ts:145](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L145)
+Defined in: [types.ts:145](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L145)
 
-Defined in: [types.ts:145](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L145)
+Defined in: [types.ts:145](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L145)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 Should the microphone listen continuously (true) or should it stop after the first utterance (false)?
 
-Defined in: [types.ts:114](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L114)
+Defined in: [types.ts:114](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L114)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 Should interim results be emitted? These are parts of an ongoing utterance for which transcription hasn't
 completed yet
 
-Defined in: [types.ts:119](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L119)
+Defined in: [types.ts:119](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L119)
 
 ___
 
@@ -67,7 +67,7 @@ Callback that is invoked when transcription ends
 
 **`param`** Event containing updates to the transcript
 
-Defined in: [types.ts:128](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L128)
+Defined in: [types.ts:128](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L128)
 
 ___
 
@@ -79,7 +79,7 @@ Callback that is invoked when an error occurs
 
 **`param`** Event containing details of the error
 
-Defined in: [types.ts:133](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L133)
+Defined in: [types.ts:133](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L133)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 Callback that is invoked whenever the transcript updates
 
-Defined in: [types.ts:123](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L123)
+Defined in: [types.ts:123](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L123)
 
 ___
 
@@ -105,9 +105,9 @@ Start transcribing utterances received from the microphone
 
 **Returns:** *Promise*<void\>
 
-Defined in: [types.ts:137](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L137)
+Defined in: [types.ts:137](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L137)
 
-Defined in: [types.ts:137](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L137)
+Defined in: [types.ts:137](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L137)
 
 ___
 
@@ -123,6 +123,6 @@ Stop transcribing utterances received from the microphone, but finish processing
 
 **Returns:** *Promise*<void\>
 
-Defined in: [types.ts:141](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L141)
+Defined in: [types.ts:141](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L141)
 
-Defined in: [types.ts:141](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L141)
+Defined in: [types.ts:141](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L141)

--- a/docs/interfaces/speechrecognitionalternative.md
+++ b/docs/interfaces/speechrecognitionalternative.md
@@ -19,7 +19,7 @@ Transcript for the ongoing utterance, including the level of confidence in that 
 
 Level of confidence in the correctness of the transcript (from 0 to 1)
 
-Defined in: [types.ts:13](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L13)
+Defined in: [types.ts:13](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L13)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 Current transcript of the ongoing utterance (the words spoken by the user)
 
-Defined in: [types.ts:9](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L9)
+Defined in: [types.ts:9](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L9)

--- a/docs/interfaces/speechrecognitionclass.md
+++ b/docs/interfaces/speechrecognitionclass.md
@@ -24,7 +24,7 @@ Constructor for a SpeechRecognition implementation
 
 **Returns:** [*SpeechRecognition*](speechrecognition.md)
 
-Defined in: [types.ts:156](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L156)
+Defined in: [types.ts:156](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L156)
 
 ## Properties
 
@@ -34,4 +34,4 @@ Defined in: [types.ts:156](https://github.com/JamesBrill/speech-recognition-poly
 
 Does the browser support the APIs needed for this polyfill?
 
-Defined in: [types.ts:156](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L156)
+Defined in: [types.ts:156](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L156)

--- a/docs/interfaces/speechrecognitionerrorevent.md
+++ b/docs/interfaces/speechrecognitionerrorevent.md
@@ -19,7 +19,7 @@ Data associated with an error emitted from the recognition service
 
 Type of error raised
 
-Defined in: [types.ts:61](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L61)
+Defined in: [types.ts:61](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L61)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 Message describing the error in more detail
 
-Defined in: [types.ts:65](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L65)
+Defined in: [types.ts:65](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L65)

--- a/docs/interfaces/speechrecognitionevent.md
+++ b/docs/interfaces/speechrecognitionevent.md
@@ -19,7 +19,7 @@ Data associated with an update to the transcript for the ongoing utterance
 
 Index of the earliest speech recognition result that has changed
 
-Defined in: [types.ts:50](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L50)
+Defined in: [types.ts:50](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L50)
 
 ___
 
@@ -32,4 +32,4 @@ native [SpeechRecognitionResultList](https://developer.mozilla.org/en-US/docs/We
 Note that the Speechly implementation currently does not maintain a history of results, only returning the single
 result for the ongoing utterance
 
-Defined in: [types.ts:46](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L46)
+Defined in: [types.ts:46](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L46)

--- a/docs/interfaces/speechrecognitionresult.md
+++ b/docs/interfaces/speechrecognitionresult.md
@@ -22,7 +22,7 @@ structure used in the native [SpeechRecognitionResult spec](https://developer.mo
 which contains an "array" of alternative transcripts. In the Speechly implementation, there is never more than one
 alternative, so only the first index is specified in the interface
 
-Defined in: [types.ts:20](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L20)
+Defined in: [types.ts:20](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L20)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 Is this transcript "final"? That is, has the transcription algorithm concluded that the utterance has finished and
 that the trancript will have no further updates?
 
-Defined in: [types.ts:32](https://github.com/JamesBrill/speech-recognition-polyfill/blob/HEAD/src/types.ts#L32)
+Defined in: [types.ts:32](https://github.com/speechly/speech-recognition-polyfill/blob/HEAD/src/types.ts#L32)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/speech-recognition-polyfill",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/speech-recognition-polyfill",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Polyfill for the Speech Recognition API using Speechly",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/createSpeechRecognition.test.ts
+++ b/src/createSpeechRecognition.test.ts
@@ -24,9 +24,11 @@ const mockOnSegmentChange = jest.fn((callback) => {
   _callback = callback;
 });
 const mockMicrophoneInitialize = jest.fn(() => Promise.resolve());
+const mockMicrophoneClose = jest.fn(() => Promise.resolve());
 const mockStart = jest.fn(() => Promise.resolve());
 const mockStop = jest.fn(() => Promise.resolve());
 const mockAttach = jest.fn(() => Promise.resolve());
+const mockDetach = jest.fn(() => Promise.resolve());
 const mockMediaStream = { data: 'mockData' };
 const MockBrowserMicrophone = mocked(BrowserMicrophone, true);
 
@@ -34,7 +36,7 @@ const mockBrowserMicrophone = ({ mediaStream }: { mediaStream: typeof mockMediaS
   MockBrowserMicrophone.mockImplementation(function () {
     return {
       initialize: mockMicrophoneInitialize,
-      close: jest.fn(),
+      close: mockMicrophoneClose,
       mediaStream,
     } as any;
   });
@@ -47,7 +49,7 @@ jest.mock('@speechly/browser-client', () => ({
       start: mockStart,
       stop: mockStop,
       attach: mockAttach,
-      detach: jest.fn(),
+      detach: mockDetach,
     };
   },
   BrowserMicrophone: jest.fn(),
@@ -69,10 +71,12 @@ describe('createSpeechlySpeechRecognition', () => {
     MockBrowserMicrophone.mockClear();
     mockBrowserMicrophone({ mediaStream: mockMediaStream });
     mockMicrophoneInitialize.mockClear();
+    mockMicrophoneClose.mockClear();
     mockStart.mockClear();
     mockStop.mockClear();
     mockOnSegmentChange.mockClear();
     mockAttach.mockClear();
+    mockDetach.mockClear();
   });
 
   it('calls initialize on browser microphone when starting transcription', async () => {
@@ -202,6 +206,8 @@ describe('createSpeechlySpeechRecognition', () => {
 
     expect(mockMicrophoneInitialize).toHaveBeenCalledTimes(0);
     expect(mockStop).toHaveBeenCalledTimes(0);
+    expect(mockDetach).toHaveBeenCalledTimes(0);
+    expect(mockMicrophoneClose).toHaveBeenCalledTimes(0);
     expect(mockOnEnd).toHaveBeenCalledTimes(0);
   })
 
@@ -216,6 +222,8 @@ describe('createSpeechlySpeechRecognition', () => {
 
     expect(mockMicrophoneInitialize).toHaveBeenCalledTimes(1);
     expect(mockStop).toHaveBeenCalledTimes(1);
+    expect(mockDetach).toHaveBeenCalledTimes(1);
+    expect(mockMicrophoneClose).toHaveBeenCalledTimes(1);
     expect(mockOnEnd).toHaveBeenCalledTimes(1);
   })
 
@@ -231,6 +239,8 @@ describe('createSpeechlySpeechRecognition', () => {
 
     expect(mockMicrophoneInitialize).toHaveBeenCalledTimes(1);
     expect(mockStop).toHaveBeenCalledTimes(1);
+    expect(mockDetach).toHaveBeenCalledTimes(1);
+    expect(mockMicrophoneClose).toHaveBeenCalledTimes(1);
     expect(mockOnEnd).toHaveBeenCalledTimes(1);
   })
 
@@ -244,6 +254,8 @@ describe('createSpeechlySpeechRecognition', () => {
 
     expect(mockMicrophoneInitialize).toHaveBeenCalledTimes(0);
     expect(mockStop).toHaveBeenCalledTimes(0);
+    expect(mockDetach).toHaveBeenCalledTimes(0);
+    expect(mockMicrophoneClose).toHaveBeenCalledTimes(0);
     expect(mockOnEnd).toHaveBeenCalledTimes(0);
   })
 
@@ -258,6 +270,8 @@ describe('createSpeechlySpeechRecognition', () => {
 
     expect(mockMicrophoneInitialize).toHaveBeenCalledTimes(1);
     expect(mockStop).toHaveBeenCalledTimes(1);
+    expect(mockDetach).toHaveBeenCalledTimes(1);
+    expect(mockMicrophoneClose).toHaveBeenCalledTimes(1);
     expect(mockOnEnd).toHaveBeenCalledTimes(1);
   })
 
@@ -273,6 +287,8 @@ describe('createSpeechlySpeechRecognition', () => {
 
     expect(mockMicrophoneInitialize).toHaveBeenCalledTimes(1);
     expect(mockStop).toHaveBeenCalledTimes(1);
+    expect(mockDetach).toHaveBeenCalledTimes(1);
+    expect(mockMicrophoneClose).toHaveBeenCalledTimes(1);
     expect(mockOnEnd).toHaveBeenCalledTimes(1);
   })
 

--- a/src/createSpeechRecognition.test.ts
+++ b/src/createSpeechRecognition.test.ts
@@ -438,11 +438,11 @@ describe('createSpeechlySpeechRecognition', () => {
   })
 
   it('calls onerror with SpeechRecognitionFailedError error when browser microphone media stream is falsey', async () => {
+    mockBrowserMicrophone({ mediaStream: null });
     const SpeechRecognition = createSpeechlySpeechRecognition('app id');
     const speechRecognition = new SpeechRecognition();
     const mockOnError = jest.fn();
     speechRecognition.onerror = mockOnError;
-    mockBrowserMicrophone({ mediaStream: null });
 
     await speechRecognition.start();
 

--- a/src/createSpeechRecognition.test.ts
+++ b/src/createSpeechRecognition.test.ts
@@ -34,6 +34,7 @@ const mockBrowserMicrophone = ({ mediaStream }: { mediaStream: typeof mockMediaS
   MockBrowserMicrophone.mockImplementation(function () {
     return {
       initialize: mockMicrophoneInitialize,
+      close: jest.fn(),
       mediaStream,
     } as any;
   });
@@ -46,6 +47,7 @@ jest.mock('@speechly/browser-client', () => ({
       start: mockStart,
       stop: mockStop,
       attach: mockAttach,
+      detach: jest.fn(),
     };
   },
   BrowserMicrophone: jest.fn(),

--- a/src/createSpeechRecognition.ts
+++ b/src/createSpeechRecognition.ts
@@ -34,9 +34,10 @@ export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitio
     static readonly hasBrowserSupport: boolean = browserSupportsAudioApis
 
     private readonly client: BrowserClient
-    private clientInitialised = false
+    private readonly microphone: BrowserMicrophone
     private aborted = false
     private transcribing = false
+    private listenPromise: Promise<void> | null = null
 
     continuous = false
     interimResults = false
@@ -46,15 +47,14 @@ export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitio
 
     constructor() {
       this.client = new BrowserClient({ appId })
+      this.microphone = new BrowserMicrophone()
       this.client.onSegmentChange(this.handleResult)
     }
 
     public start = async (): Promise<void> => {
       try {
         this.aborted = false
-        await this.initialise()
-        await this.client.start()
-        this.transcribing = true
+        await this._start()
       } catch (e) {
         if (e === ErrNoAudioConsent) {
           this.onerror(MicrophoneNotAllowedError)
@@ -73,31 +73,49 @@ export const createSpeechlySpeechRecognition = (appId: string): SpeechRecognitio
       await this._stop()
     }
 
-    private readonly initialise = async (): Promise<void> => {
-      if (!this.clientInitialised) {
-        const microphone = new BrowserMicrophone()
-        await microphone.initialize()
-        const { mediaStream } = microphone
+    private readonly _start = async (): Promise<void> => {
+      if (this.transcribing) {
+        return
+      }
+
+      this.transcribing = true
+
+      this.listenPromise = (async () => {
+        // Wait for earlier task(s) to complete, effectively adding to a task queue
+        await this.listenPromise
+        await this.microphone.initialize()
+        const { mediaStream } = this.microphone
         if (mediaStream === null || mediaStream === undefined) {
           throw ErrDeviceNotSupported
         }
         await this.client.attach(mediaStream)
-        this.clientInitialised = true
-      }
+        await this.client.start()
+      })()
+
+      await this.listenPromise
     }
 
     private readonly _stop = async (): Promise<void> => {
       if (!this.transcribing) {
         return
       }
-      await this.initialise()
-      try {
-        await this.client.stop()
-        this.transcribing = false
-        this.onend()
-      } catch (e) {
-        // swallow errors
-      }
+
+      this.transcribing = false
+
+      this.listenPromise = (async () => {
+        // Wait for earlier task(s) to complete, effectively adding to a task queue
+        await this.listenPromise
+        try {
+          await this.client.stop()
+          await this.client.detach()
+          await this.microphone.close()
+          this.onend()
+        } catch (e) {
+          // swallow errors
+        }
+      })()
+
+      await this.listenPromise
     }
 
     private readonly handleResult = (segment: Segment): void => {


### PR DESCRIPTION
### What

This PR applies the patch suggested [here](https://github.com/speechly/speech-recognition-polyfill/issues/30#issuecomment-1288656895), which should close the mic when the polyfill is inactive.

Note that this PR contains unrelated doc changes that update the repo link - these can be ignored.


### Why

Intended to resolve issue https://github.com/speechly/speech-recognition-polyfill/issues/30 where microphone indicator is still turned on even when polyfill is turned off, which can affect user trust in a web app. 
